### PR TITLE
fix(showbackgoclient): set default scheme to https instead of http

### DIFF
--- a/showbackclient/showbackgoclient_client.go
+++ b/showbackclient/showbackgoclient_client.go
@@ -29,7 +29,7 @@ const (
 )
 
 // DefaultSchemes are the default schemes found in Meta (info) section of spec file
-var DefaultSchemes = []string{"http"}
+var DefaultSchemes = []string{"https"}
 
 // NewHTTPClient creates a new showbackgoclient HTTP client.
 func NewHTTPClient(formats strfmt.Registry) *Showbackgoclient {

--- a/showbackclient/showbackgoclient_client.go
+++ b/showbackclient/showbackgoclient_client.go
@@ -22,7 +22,7 @@ var Default = NewHTTPClient(nil)
 const (
 	// DefaultHost is the default Host
 	// found in Meta (info) section of spec file
-	DefaultHost string = "localhost"
+	DefaultHost string = "api.taikun.dev"
 	// DefaultBasePath is the default BasePath
 	// found in Meta (info) section of spec file
 	DefaultBasePath string = "/"


### PR DESCRIPTION
All showback client methods were failing with 401 Unauthorized due to the default scheme of the showbackgoclient being set to HTTP instead of HTTPS (as is the case in taikungoclient).