### PR TITLE
build: add -compat=1.17 flag to go mod tidy

### DIFF
--- a/.github/generate_client.sh
+++ b/.github/generate_client.sh
@@ -61,4 +61,4 @@ sed -i "/${refline}/r .github/codegen/media_type_support_code.go" "${showback_cl
 go fmt "${showback_client_definition_file}"
 
 # Tidy go module
-go mod tidy
+go mod tidy -compat=1.17


### PR DESCRIPTION
The Generate Dev Client worflow failed with the following error.

```
github.com/itera-io/***goclient/client/access_profiles imports
	github.com/go-openapi/swag imports
	gopkg.in/yaml.v3 tested by
	gopkg.in/yaml.v3.test imports
	gopkg.in/check.v1 imports
	github.com/kr/pretty loaded from github.com/kr/pretty@v0.1.0,
	but go 1.16 would select v0.2.1

To upgrade to the versions selected by go 1.16:
	go mod tidy -go=1.16 && go mod tidy -go=1.17
If reproducibility with go 1.16 is not needed:
	go mod tidy -compat=1.17
For other options, see:
	https://golang.org/doc/modules/pruning
Error: Process completed with exit code 1.
```

As reproducibility with go 1.16 is not needed, the flag `-compat=1.17`
was added to the `go mod tidy` command in the
`.github/generate_client.sh` script.